### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ In `Woocommerce-Payment-Network.php` change the following to match your brand
 
 1. Line 7 to reflect your brand
 2. Line 8 to reflect your own domain
-3. Line line 12 to reflect your support details
+3. Line 12 to reflect your support details
+4. Line 74 replace PaymentNetwork in the admin_url with your $gateway (as below, with no spaces)
 
 In file `includes/class-wc-payment-network.php` change the following to match that you've been provided:
 


### PR DESCRIPTION
The 'Settings' button on the plugins list will not work if $gateway is anything other than PaymentNetwork.
admin_url must be amended to match $gateway in class-wc-payment-network.php (with any spaces removed).  